### PR TITLE
reduce memory consumption

### DIFF
--- a/src/Resources/contao/dca/tl_comments.php
+++ b/src/Resources/contao/dca/tl_comments.php
@@ -198,7 +198,7 @@ $GLOBALS['TL_DCA']['tl_comments'] = array
 			'foreignKey'              => 'tl_user.name',
 			'eval'                    => array('mandatory'=>true, 'chosen'=>true, 'doNotCopy'=>true, 'includeBlankOption'=>true, 'tl_class'=>'w50'),
 			'sql'                     => "int(10) unsigned NOT NULL default '0'",
-			'relation'                => array('type'=>'belongsTo', 'load'=>'eager')
+			'relation'                => array('type'=>'belongsTo', 'load'=>'lazy')
 		),
 		'reply' => array
 		(


### PR DESCRIPTION
If a page shows a lot of comments with a lot of back end user replies, the memory consumption could potentiallly be higher than needed.

However, this problem should not be as severe as https://github.com/contao/news-bundle/pull/37